### PR TITLE
sDAI subpage

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:ci": "jest --ci"
   },
   "dependencies": {
-    "@aave/contract-helpers": "npm:@blank101/contract-helpers@1.13.6",
+    "@aave/contract-helpers": "npm:@marsfoundation/contract-helpers@1.13.7",
     "@aave/math-utils": "^1.13.5",
     "@bgd-labs/aave-address-book": "^1.13.1",
     "@emotion/cache": "11.10.3",

--- a/pages/sdai.page.tsx
+++ b/pages/sdai.page.tsx
@@ -8,18 +8,21 @@ import { MainLayout } from 'src/layouts/MainLayout';
 import { SDAITopPanel } from 'src/modules/sdai/SDAITopPanel';
 
 export default function SDAI() {
-  const { loading } = useAppDataContext();
+  const { loading, reserves } = useAppDataContext();
+
+  const daiMarket = reserves.find((reserve) => reserve.symbol === 'DAI');
+  const sDaiMarket = reserves.find((reserve) => reserve.symbol === 'sDAI');
 
   return (
     <>
       <>
         <SDAITopPanel />
         <ContentContainer>
-          {!loading && (
+          {!loading && daiMarket && (
             <ListWrapper titleComponent={'sDAI'}>
               <ModalWrapper
                 title={<Trans>Swap to</Trans>}
-                underlyingAsset={'0x11fe4b6ae13d2a6055c8d9cf65c55bac32b5d844'}
+                underlyingAsset={daiMarket.underlyingAsset.toString()}
               >
                 {(params) => <PSMSwapModalContent {...params} />}
               </ModalWrapper>

--- a/pages/sdai.page.tsx
+++ b/pages/sdai.page.tsx
@@ -1,0 +1,13 @@
+import { MainLayout } from 'src/layouts/MainLayout';
+
+export default function SDAI() {
+  return (
+    <>
+      <h1>sDAI</h1>
+    </>
+  );
+}
+
+SDAI.getLayout = function getLayout(page: React.ReactElement) {
+  return <MainLayout>{page}</MainLayout>;
+};

--- a/pages/sdai.page.tsx
+++ b/pages/sdai.page.tsx
@@ -88,8 +88,9 @@ export default function SDAI() {
                   <ModalWrapper
                     title={<Trans>Swap to</Trans>}
                     underlyingAsset={currentMarket.underlyingAsset.toString()}
+                    key={mode} // forces component to be destroyed and recreated from scratch. These modal components are not written to handle re-renders with different props.
                   >
-                    {(params) => <PSMSwapModalContent {...params} />}
+                    {(params) => <PSMSwapModalContent {...params} hideSwitchSourceToken />}
                   </ModalWrapper>
                 </Box>
               </ListWrapper>

--- a/pages/sdai.page.tsx
+++ b/pages/sdai.page.tsx
@@ -1,4 +1,6 @@
 import { Trans } from '@lingui/macro';
+import { Warning } from 'src/components/primitives/Warning';
+import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { ContentContainer } from 'src/components/ContentContainer';
 import { ListWrapper } from 'src/components/lists/ListWrapper';
 import { ModalWrapper } from 'src/components/transactions/FlowCommons/ModalWrapper';
@@ -6,27 +8,64 @@ import { PSMSwapModalContent } from 'src/components/transactions/PSMSwap/PSMSwap
 import { useAppDataContext } from 'src/hooks/app-data-provider/useAppDataProvider';
 import { MainLayout } from 'src/layouts/MainLayout';
 import { SDAITopPanel } from 'src/modules/sdai/SDAITopPanel';
+import { BigNumber } from 'bignumber.js';
 
 export default function SDAI() {
-  const { loading, reserves } = useAppDataContext();
+  const { loading: globalLoading, reserves, dsr } = useAppDataContext();
 
-  const daiMarket = reserves.find((reserve) => reserve.symbol === 'DAI');
-  const sDaiMarket = reserves.find((reserve) => reserve.symbol === 'sDAI');
+  const daiMarket = reserves.find((reserve) => reserve.symbol === 'DAI')!;
+  const sDaiMarket = reserves.find((reserve) => reserve.symbol === 'sDAI')!;
+
+  const loading = globalLoading || !dsr || !reserves;
+
+  const { breakpoints } = useTheme();
+  const isDesktop = useMediaQuery(breakpoints.up('lg'));
+  const paperWidth = isDesktop ? 'calc(50% - 8px)' : '100%';
 
   return (
     <>
       <>
         <SDAITopPanel />
         <ContentContainer>
-          {!loading && daiMarket && (
-            <ListWrapper titleComponent={'sDAI'}>
-              <ModalWrapper
-                title={<Trans>Swap to</Trans>}
-                underlyingAsset={daiMarket.underlyingAsset.toString()}
+          {!loading && (
+            <Box
+              sx={{ display: 'block', width: paperWidth, marginLeft: 'auto', marginRight: 'auto' }}
+            >
+              <ListWrapper
+                titleComponent={
+                  <Typography component="div" variant="h2" sx={{ mr: 4 }}>
+                    <Trans>Savings DAI</Trans>
+                  </Typography>
+                }
               >
-                {(params) => <PSMSwapModalContent {...params} />}
-              </ModalWrapper>
-            </ListWrapper>
+                <Box sx={{ px: { xs: 4, xsm: 6 } }}>
+                  <Warning severity="info">
+                    <Trans>
+                      sDAI is similar to DAI but with the added benefit of earning interest
+                      (currently at <strong>{formatPercent(dsr)}</strong>). You can use it just like
+                      DAI - own, transfer, and use it in the DeFi ecosystem. Swapping between sDAI
+                      and DAI incurs no additional costs, and there is no slippage.
+                    </Trans>
+                  </Warning>
+                </Box>
+
+                <Box
+                  sx={{
+                    m: 10,
+                    p: { xs: 4, xsm: 6 },
+                    bgcolor: 'background.paper',
+                    borderRadius: '8px',
+                  }}
+                >
+                  <ModalWrapper
+                    title={<Trans>Swap to</Trans>}
+                    underlyingAsset={daiMarket.underlyingAsset.toString()}
+                  >
+                    {(params) => <PSMSwapModalContent {...params} />}
+                  </ModalWrapper>
+                </Box>
+              </ListWrapper>
+            </Box>
           )}
         </ContentContainer>
       </>
@@ -37,3 +76,7 @@ export default function SDAI() {
 SDAI.getLayout = function getLayout(page: React.ReactElement) {
   return <MainLayout>{page}</MainLayout>;
 };
+
+function formatPercent(value: BigNumber): string {
+  return `${value.multipliedBy(100).toNumber().toFixed(2)}%`;
+}

--- a/pages/sdai.page.tsx
+++ b/pages/sdai.page.tsx
@@ -19,7 +19,7 @@ export default function SDAI() {
 
   const daiMarket = reserves.find((reserve) => reserve.symbol === 'DAI')!;
   const sDaiMarket = reserves.find((reserve) => reserve.symbol === 'sDAI')!;
-  const currentMarket = mode === 'dai-to-sdai' ? daiMarket : sDaiMarket;
+  const currentMarket = mode === 'dai-to-sdai' ? sDaiMarket : daiMarket;
 
   const loading = globalLoading || !dsr || !reserves;
 

--- a/pages/sdai.page.tsx
+++ b/pages/sdai.page.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro';
 import { Warning } from 'src/components/primitives/Warning';
-import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { Box, Stack, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { ContentContainer } from 'src/components/ContentContainer';
 import { ListWrapper } from 'src/components/lists/ListWrapper';
 import { ModalWrapper } from 'src/components/transactions/FlowCommons/ModalWrapper';
@@ -12,6 +12,7 @@ import { BigNumber } from 'bignumber.js';
 import StyledToggleButtonGroup from 'src/components/StyledToggleButtonGroup';
 import StyledToggleButton from 'src/components/StyledToggleButton';
 import { useState } from 'react';
+import { SDAIEtherscanLink } from 'src/modules/sdai/SDAIEtherscanLink';
 
 export default function SDAI() {
   const { loading: globalLoading, reserves, dsr } = useAppDataContext();
@@ -38,9 +39,17 @@ export default function SDAI() {
             >
               <ListWrapper
                 titleComponent={
-                  <Typography component="div" variant="h2" sx={{ mr: 4 }}>
-                    <Trans>Savings DAI</Trans>
-                  </Typography>
+                  <Stack
+                    direction="row"
+                    alignItems="center"
+                    justifyContent="space-between"
+                    sx={{ width: '100%' }}
+                  >
+                    <Typography component="div" variant="h2" sx={{ mr: 4 }}>
+                      <Trans>Savings DAI</Trans>
+                    </Typography>
+                    <SDAIEtherscanLink />
+                  </Stack>
                 }
               >
                 <Box sx={{ px: { xs: 4, xsm: 6 } }}>

--- a/pages/sdai.page.tsx
+++ b/pages/sdai.page.tsx
@@ -1,9 +1,32 @@
+import { Trans } from '@lingui/macro';
+import { ContentContainer } from 'src/components/ContentContainer';
+import { ListWrapper } from 'src/components/lists/ListWrapper';
+import { ModalWrapper } from 'src/components/transactions/FlowCommons/ModalWrapper';
+import { PSMSwapModalContent } from 'src/components/transactions/PSMSwap/PSMSwapModalContent';
+import { useAppDataContext } from 'src/hooks/app-data-provider/useAppDataProvider';
 import { MainLayout } from 'src/layouts/MainLayout';
+import { SDAITopPanel } from 'src/modules/sdai/SDAITopPanel';
 
 export default function SDAI() {
+  const { loading } = useAppDataContext();
+
   return (
     <>
-      <h1>sDAI</h1>
+      <>
+        <SDAITopPanel />
+        <ContentContainer>
+          {!loading && (
+            <ListWrapper titleComponent={'sDAI'}>
+              <ModalWrapper
+                title={<Trans>Swap to</Trans>}
+                underlyingAsset={'0x11fe4b6ae13d2a6055c8d9cf65c55bac32b5d844'}
+              >
+                {(params) => <PSMSwapModalContent {...params} />}
+              </ModalWrapper>
+            </ListWrapper>
+          )}
+        </ContentContainer>
+      </>
     </>
   );
 }

--- a/pages/sdai.page.tsx
+++ b/pages/sdai.page.tsx
@@ -9,12 +9,17 @@ import { useAppDataContext } from 'src/hooks/app-data-provider/useAppDataProvide
 import { MainLayout } from 'src/layouts/MainLayout';
 import { SDAITopPanel } from 'src/modules/sdai/SDAITopPanel';
 import { BigNumber } from 'bignumber.js';
+import StyledToggleButtonGroup from 'src/components/StyledToggleButtonGroup';
+import StyledToggleButton from 'src/components/StyledToggleButton';
+import { useState } from 'react';
 
 export default function SDAI() {
   const { loading: globalLoading, reserves, dsr } = useAppDataContext();
+  const [mode, setMode] = useState<'dai-to-sdai' | 'sdai-to-dai'>('dai-to-sdai');
 
   const daiMarket = reserves.find((reserve) => reserve.symbol === 'DAI')!;
   const sDaiMarket = reserves.find((reserve) => reserve.symbol === 'sDAI')!;
+  const currentMarket = mode === 'dai-to-sdai' ? daiMarket : sDaiMarket;
 
   const loading = globalLoading || !dsr || !reserves;
 
@@ -57,9 +62,32 @@ export default function SDAI() {
                     borderRadius: '8px',
                   }}
                 >
+                  <StyledToggleButtonGroup
+                    color="primary"
+                    value={mode}
+                    exclusive
+                    onChange={(_, value) => setMode(value)}
+                    sx={{
+                      width: '100%',
+                      height: '44px',
+                      marginBottom: '20px',
+                    }}
+                  >
+                    <StyledToggleButton value="dai-to-sdai" disabled={mode === 'dai-to-sdai'}>
+                      <Typography variant="subheader1">
+                        <Trans>DAI → sDAI</Trans>
+                      </Typography>
+                    </StyledToggleButton>
+                    <StyledToggleButton value="sdai-to-dai" disabled={mode === 'sdai-to-dai'}>
+                      <Typography variant="subheader1">
+                        <Trans>sDAI → DAI</Trans>
+                      </Typography>
+                    </StyledToggleButton>
+                  </StyledToggleButtonGroup>
+
                   <ModalWrapper
                     title={<Trans>Swap to</Trans>}
-                    underlyingAsset={daiMarket.underlyingAsset.toString()}
+                    underlyingAsset={currentMarket.underlyingAsset.toString()}
                   >
                     {(params) => <PSMSwapModalContent {...params} />}
                   </ModalWrapper>

--- a/src/components/primitives/Link.tsx
+++ b/src/components/primitives/Link.tsx
@@ -116,6 +116,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link
 export const ROUTES = {
   dashboard: '/',
   markets: '/markets',
+  sDAI: '/sdai',
   staking: '/staking',
   governance: '/governance',
   faucet: '/faucet',

--- a/src/components/transactions/FlowCommons/ModalWrapper.tsx
+++ b/src/components/transactions/FlowCommons/ModalWrapper.tsx
@@ -27,6 +27,7 @@ export interface ModalWrapperProps {
   tokenBalance: string;
   nativeBalance: string;
   isWrongNetwork: boolean;
+  hideSwitchSourceToken?: boolean;
 }
 
 export const ModalWrapper: React.FC<{

--- a/src/components/transactions/FlowCommons/Success.tsx
+++ b/src/components/transactions/FlowCommons/Success.tsx
@@ -3,6 +3,7 @@ import { ExternalLinkIcon } from '@heroicons/react/outline';
 import { CheckIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/macro';
 import { Box, Button, Link, SvgIcon, Typography, useTheme } from '@mui/material';
+import { useRouter } from 'next/router';
 import { ReactNode, useState } from 'react';
 import { WalletIcon } from 'src/components/icons/WalletIcon';
 import { FormattedNumber } from 'src/components/primitives/FormattedNumber';
@@ -42,6 +43,8 @@ export const TxSuccessView = ({
   const { currentNetworkConfig } = useProtocolDataContext();
   const [base64, setBase64] = useState('');
   const theme = useTheme();
+  const router = useRouter();
+  const isOnSDaiPage = router.pathname === '/sdai';
 
   return (
     <>
@@ -190,7 +193,7 @@ export const TxSuccessView = ({
           sx={{ minHeight: '44px' }}
           data-cy="closeButton"
         >
-          <Trans>Ok, Close</Trans>
+          <Trans>Ok, {isOnSDaiPage ? 'Done' : 'Close'}</Trans>
         </Button>
       </Box>
     </>

--- a/src/components/transactions/PSMSwap/PSMSwapModalContent.tsx
+++ b/src/components/transactions/PSMSwap/PSMSwapModalContent.tsx
@@ -22,7 +22,11 @@ import { ModalWrapperProps } from '../FlowCommons/ModalWrapper';
 import { TxSuccessView } from '../FlowCommons/Success';
 import { PSMSwapActions, PSMSwapActionType } from './PSMSwapActions';
 
-export const PSMSwapModalContent = ({ poolReserve, isWrongNetwork }: ModalWrapperProps) => {
+export const PSMSwapModalContent = ({
+  poolReserve,
+  isWrongNetwork,
+  hideSwitchSourceToken,
+}: ModalWrapperProps) => {
   const { marketReferencePriceInUsd, reserves, chi, tin, tout } = useAppDataContext();
   const { gasLimit, mainTxState: supplyTxState, txError } = useModalContext();
   const { walletBalances } = useWalletBalances();
@@ -102,7 +106,7 @@ export const PSMSwapModalContent = ({ poolReserve, isWrongNetwork }: ModalWrappe
 
   return (
     <>
-      {currentValidTypes.length > 1 ? (
+      {currentValidTypes.length > 1 && !hideSwitchSourceToken ? (
         <Link sx={{ fontWeight: 'bold' }} href="#" onClick={handleTypeChange}>
           Switch Source Token
         </Link>

--- a/src/hooks/app-data-provider/useAppDataProvider.tsx
+++ b/src/hooks/app-data-provider/useAppDataProvider.tsx
@@ -21,6 +21,7 @@ import {
   selectDSR,
   selectEmodes,
   selectFormattedReserves,
+  selectSDaiTotalAssets,
   selectTin,
   selectTout,
   selectUserSummaryAndIncentives,
@@ -70,6 +71,7 @@ export interface AppDataContextType {
   chi?: BigNumber;
   tin?: BigNumber;
   tout?: BigNumber;
+  sDaiTotalAssets?: BigNumber;
 }
 
 const AppDataContext = React.createContext<AppDataContextType>({} as AppDataContextType);
@@ -93,6 +95,7 @@ export const AppDataProvider: React.FC = ({ children }) => {
     tout,
     formattedPoolReserves,
     user,
+    sDaiTotalAssets,
   ] = useRootStore((state) => [
     selectCurrentReserves(state),
     selectCurrentBaseCurrencyData(state),
@@ -105,6 +108,7 @@ export const AppDataProvider: React.FC = ({ children }) => {
     selectTout(state),
     selectFormattedReserves(state, currentTimestamp),
     selectUserSummaryAndIncentives(state, currentTimestamp),
+    selectSDaiTotalAssets(state),
   ]);
 
   const proportions = user.userReservesData.reduce(
@@ -199,6 +203,7 @@ export const AppDataProvider: React.FC = ({ children }) => {
         chi,
         tin,
         tout,
+        sDaiTotalAssets,
       }}
     >
       {children}

--- a/src/modules/sdai/DSRTooltip.tsx
+++ b/src/modules/sdai/DSRTooltip.tsx
@@ -1,0 +1,13 @@
+import { Trans } from '@lingui/macro';
+import { TextWithTooltip, TextWithTooltipProps } from 'src/components/TextWithTooltip';
+
+export const DSRTooltip = ({ ...rest }: TextWithTooltipProps) => {
+  return (
+    <TextWithTooltip {...rest}>
+      <Trans>
+        The yield comes from fees paid by DAI borrowers. The DSR rate is subject to change based on
+        MakerDAO governance votes.
+      </Trans>
+    </TextWithTooltip>
+  );
+};

--- a/src/modules/sdai/SDAIEtherscanLink.tsx
+++ b/src/modules/sdai/SDAIEtherscanLink.tsx
@@ -1,0 +1,46 @@
+import { ExternalLinkIcon } from '@heroicons/react/outline';
+import { Trans } from '@lingui/macro';
+import { Button, SvgIcon, Typography } from '@mui/material';
+import { useProtocolDataContext } from 'src/hooks/useProtocolDataContext';
+
+import { DarkTooltip } from 'src/components/infoTooltips/DarkTooltip';
+import { Link } from 'src/components/primitives/Link';
+import { useAppDataContext } from 'src/hooks/app-data-provider/useAppDataProvider';
+
+export const SDAIEtherscanLink = () => {
+  const { currentNetworkConfig } = useProtocolDataContext();
+  const { loading, reserves } = useAppDataContext();
+  const sDaiReserve = reserves.find((reserve) => reserve.symbol === 'sDAI');
+  const sDaiAddress = sDaiReserve?.underlyingAsset;
+
+  if (loading) {
+    return <></>;
+  }
+
+  return (
+    <DarkTooltip title="sDAI Contract">
+      <Button
+        startIcon={
+          <img
+            src={currentNetworkConfig.networkLogoPath}
+            alt={currentNetworkConfig.name}
+            style={{ width: 14, height: 14 }}
+          />
+        }
+        endIcon={
+          <SvgIcon sx={{ width: 14, height: 14 }}>
+            <ExternalLinkIcon />
+          </SvgIcon>
+        }
+        component={Link}
+        href={currentNetworkConfig.explorerLinkBuilder({ address: sDaiAddress })}
+        variant="outlined"
+        size="small"
+      >
+        <Typography variant="buttonS">
+          <Trans>sDAI Contract</Trans>
+        </Typography>
+      </Button>
+    </DarkTooltip>
+  );
+};

--- a/src/modules/sdai/SDAITopPanel.tsx
+++ b/src/modules/sdai/SDAITopPanel.tsx
@@ -5,14 +5,20 @@ import * as React from 'react';
 
 import NetAPYIcon from '../../../public/icons/markets/net-apy-icon.svg';
 import PieIcon from '../../../public/icons/markets/pie-icon.svg';
+import WalletIcon from '../../../public/icons/markets/wallet-icon.svg';
 import { FormattedNumber } from '../../components/primitives/FormattedNumber';
 import { TopInfoPanel } from '../../components/TopInfoPanel/TopInfoPanel';
 import { TopInfoPanelItem } from '../../components/TopInfoPanel/TopInfoPanelItem';
 import { useAppDataContext } from '../../hooks/app-data-provider/useAppDataProvider';
 import { DSRTooltip } from './DSRTooltip';
+import { useWalletBalances } from 'src/hooks/app-data-provider/useWalletBalances';
 
 export const SDAITopPanel = () => {
-  const { loading, dsr, sDaiTotalAssets } = useAppDataContext();
+  const { loading: appDataLoading, dsr, sDaiTotalAssets, reserves } = useAppDataContext();
+  const { loading: walletLoading, walletBalances } = useWalletBalances();
+  const loading = appDataLoading || walletLoading;
+  const sDaiReserve = reserves.find((reserve) => reserve.symbol === 'sDAI');
+  const sDaiBalance = walletBalances[sDaiReserve?.underlyingAsset!]?.amount;
 
   const theme = useTheme();
   const downToSM = useMediaQuery(theme.breakpoints.down('sm'));
@@ -35,17 +41,18 @@ export const SDAITopPanel = () => {
           />
         )}
       </TopInfoPanelItem>
-      {dsr && (
-        <TopInfoPanelItem
-          icon={<NetAPYIcon />}
-          title={
-            <div style={{ display: 'flex' }}>
-              <Trans>DSR Rate</Trans>
-              <DSRTooltip />
-            </div>
-          }
-          loading={loading}
-        >
+
+      <TopInfoPanelItem
+        icon={<NetAPYIcon />}
+        title={
+          <div style={{ display: 'flex' }}>
+            <Trans>DSR Rate</Trans>
+            <DSRTooltip />
+          </div>
+        }
+        loading={loading}
+      >
+        {dsr && (
           <FormattedNumber
             value={dsr}
             variant={valueTypographyVariant}
@@ -54,8 +61,26 @@ export const SDAITopPanel = () => {
             symbolsColor="#A5A8B6"
             symbolsVariant={symbolsVariant}
           />
-        </TopInfoPanelItem>
-      )}
+        )}
+      </TopInfoPanelItem>
+
+      <TopInfoPanelItem
+        icon={<WalletIcon />}
+        title={<Trans>Your sDAI balance</Trans>}
+        loading={loading}
+      >
+        {sDaiBalance && (
+          <FormattedNumber
+            value={sDaiBalance}
+            symbol="sDAI"
+            variant={valueTypographyVariant}
+            visibleDecimals={2}
+            compact
+            symbolsColor="#A5A8B6"
+            symbolsVariant={symbolsVariant}
+          />
+        )}
+      </TopInfoPanelItem>
     </TopInfoPanel>
   );
 };

--- a/src/modules/sdai/SDAITopPanel.tsx
+++ b/src/modules/sdai/SDAITopPanel.tsx
@@ -1,0 +1,61 @@
+import { valueToBigNumber } from '@aave/math-utils';
+import { Trans } from '@lingui/macro';
+import { useMediaQuery, useTheme } from '@mui/material';
+import * as React from 'react';
+
+import NetAPYIcon from '../../../public/icons/markets/net-apy-icon.svg';
+import PieIcon from '../../../public/icons/markets/pie-icon.svg';
+import { FormattedNumber } from '../../components/primitives/FormattedNumber';
+import { TopInfoPanel } from '../../components/TopInfoPanel/TopInfoPanel';
+import { TopInfoPanelItem } from '../../components/TopInfoPanel/TopInfoPanelItem';
+import { useAppDataContext } from '../../hooks/app-data-provider/useAppDataProvider';
+import { DSRTooltip } from './DSRTooltip';
+
+export const SDAITopPanel = () => {
+  const { loading, dsr, sDaiTotalAssets } = useAppDataContext();
+
+  const theme = useTheme();
+  const downToSM = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const valueTypographyVariant = downToSM ? 'main16' : 'main21';
+  const symbolsVariant = downToSM ? 'secondary16' : 'secondary21';
+
+  return (
+    <TopInfoPanel pageTitle={<Trans>sDAI</Trans>}>
+      <TopInfoPanelItem icon={<PieIcon />} title={<Trans>sDAI Market cap</Trans>} loading={loading}>
+        {sDaiTotalAssets && (
+          <FormattedNumber
+            value={sDaiTotalAssets}
+            symbol="DAI"
+            variant={valueTypographyVariant}
+            visibleDecimals={2}
+            compact
+            symbolsColor="#A5A8B6"
+            symbolsVariant={symbolsVariant}
+          />
+        )}
+      </TopInfoPanelItem>
+      {dsr && (
+        <TopInfoPanelItem
+          icon={<NetAPYIcon />}
+          title={
+            <div style={{ display: 'flex' }}>
+              <Trans>DSR Rate</Trans>
+              <DSRTooltip />
+            </div>
+          }
+          loading={loading}
+        >
+          <FormattedNumber
+            value={dsr}
+            variant={valueTypographyVariant}
+            visibleDecimals={2}
+            percent
+            symbolsColor="#A5A8B6"
+            symbolsVariant={symbolsVariant}
+          />
+        </TopInfoPanelItem>
+      )}
+    </TopInfoPanel>
+  );
+};

--- a/src/store/poolSelectors.ts
+++ b/src/store/poolSelectors.ts
@@ -95,6 +95,9 @@ export const selectCurrentReserves = (state: RootStore) => {
 export const selectDSR = (state: RootStore) => {
   return selectCurrentUserLendingPoolData(state)?.dsr;
 };
+export const selectSDaiTotalAssets = (state: RootStore) => {
+  return selectCurrentUserLendingPoolData(state)?.sDaiTotalAssets;
+};
 
 export const selectChi = (state: RootStore) => {
   return selectCurrentUserLendingPoolData(state)?.chi;

--- a/src/ui-config/menu-items/index.tsx
+++ b/src/ui-config/menu-items/index.tsx
@@ -28,6 +28,11 @@ export const navigation: Navigation[] = [
     dataCy: 'menuMarkets',
   },
   {
+    link: ROUTES.sDAI,
+    title: `sDAI`,
+    dataCy: 'menuSDAI',
+  },
+  {
     link: ROUTES.staking,
     title: t`Stake`,
     dataCy: 'menuStake',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@aave/contract-helpers@npm:@blank101/contract-helpers@1.13.6":
-  version "1.13.6"
-  resolved "https://registry.yarnpkg.com/@blank101/contract-helpers/-/contract-helpers-1.13.6.tgz#68a3f4b6057d8ec213b0e22e17b3be5364aa2bc7"
-  integrity sha512-cECEHSeCb2sNReCJx+xTuCFBDoNRm1LSFGOm+5hiO7faOL+a135vMgToBlLIQqyWkLzm/eVXf1sk8uLeRLpSYQ==
+"@aave/contract-helpers@npm:@marsfoundation/contract-helpers@1.13.7":
+  version "1.13.7"
+  resolved "https://registry.yarnpkg.com/@marsfoundation/contract-helpers/-/contract-helpers-1.13.7.tgz#af15db8f6ab3a1e44cadf28898f5580874f827e9"
+  integrity sha512-qTMN0hlp1dOCfZsXIKqEXUpDuL8Ka7T/5ZRDjmpZqT3MDjoZUS2ePWaQUILvGD2d6xGORz7MF2lkrKAb+x0uug==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 


### PR DESCRIPTION
## General Changes
* sDAI subpage allowing to easily wrap/unwrap
* built mostly by composing already existing components (swap modal)

<img width="1262" alt="image" src="https://github.com/marsfoundation/spark-interface/assets/1814312/f1546eb1-44cb-4613-9c65-debf747a886e">
 
[Spark utils fixes](https://github.com/marsfoundation/spark-utilities/pull/100) should be merged and published before final testing occurs. 

Closes FRO-9